### PR TITLE
Replace template PPP overview

### DIFF
--- a/docs/team/johndoe.md
+++ b/docs/team/johndoe.md
@@ -3,9 +3,11 @@
   title: "John Doe's Project Portfolio Page"
 ---
 
-### Project: AddressBook Level 3
+### Project: HRMate
 
-AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+HRMate is a desktop address book application that aims to streamline HR processes, by offering an intuitive, CLI-based
+contact management system with specialised functionalities for HR tasks. It has a GUI created with JavaFX, and is
+written in Java with about 10 kLoC.
 
 Given below are my contributions to the project.
 


### PR DESCRIPTION
The default template PPP (teams/johndoe.md) contains references to AddressBook-3. We keep this default template as a reference for team members' own PPP. At the same time, the overview section is modified to refer to HRMate instead, so that team members can copy this template without having to write their own overviews.