### PR TITLE
Implement import and export commands.

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -79,7 +79,7 @@ public class MainApp extends Application {
         ReadOnlyAddressBook initialData;
         try {
             addressBookOptional = storage.readAddressBook();
-            if (!addressBookOptional.isPresent()) {
+            if (addressBookOptional.isEmpty()) {
                 logger.info("Creating a new data file " + storage.getAddressBookFilePath()
                         + " populated with a sample AddressBook.");
             }

--- a/src/main/java/seedu/address/commons/controllers/FileDialogHandler.java
+++ b/src/main/java/seedu/address/commons/controllers/FileDialogHandler.java
@@ -1,0 +1,13 @@
+package seedu.address.commons.controllers;
+
+import java.io.File;
+import java.util.Optional;
+
+import javafx.stage.FileChooser.ExtensionFilter;
+
+/**
+ * Interface for a handler that handles file dialogs (e.g. open file dialog)
+ */
+public interface FileDialogHandler {
+    Optional<File> openFile(String title, ExtensionFilter... extensions);
+}

--- a/src/main/java/seedu/address/commons/controllers/FileDialogHandlerImpl.java
+++ b/src/main/java/seedu/address/commons/controllers/FileDialogHandlerImpl.java
@@ -1,0 +1,34 @@
+package seedu.address.commons.controllers;
+
+import java.io.File;
+import java.util.Optional;
+
+import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
+
+/**
+ * Handles file dialogs
+ */
+public class FileDialogHandlerImpl implements FileDialogHandler {
+
+    public static final ExtensionFilter CSV_EXTENSION = new ExtensionFilter("CSV Files", "*.csv");
+    public static final String CSV_SUFFIX = ".csv";
+
+    /**
+     * Creates a file dialog for the user to select a file to open
+     * @param title Title of dialog
+     * @param extensions Extension filters that contain the permitted file extensions
+     * @return An Optional object containing the file if selected, else an empty Optional object
+     */
+    @Override
+    public Optional<File> openFile(String title, ExtensionFilter ...extensions) {
+        FileChooser fc = new FileChooser();
+        fc.setTitle(title);
+        fc.getExtensionFilters().addAll(extensions);
+        File selectedFile = fc.showOpenDialog(null);
+        if (selectedFile != null) {
+            return Optional.of(selectedFile);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -18,7 +18,7 @@ public class ExportCommand extends Command {
 
     public static final String EXPORT_DEST = "export";
 
-    public static final String MESSAGE_USAGE = ": Exports records from CSV file. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports records from CSV file. "
             + "Parameters: "
             + "FILENAME";
 

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -1,0 +1,66 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import seedu.address.commons.util.FileUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Exports records to file
+ */
+public class ExportCommand extends Command {
+
+    public static final String COMMAND_WORD = "export";
+
+    public static final String EXPORT_DEST = "export";
+
+    public static final String MESSAGE_USAGE = ": Exports records from CSV file. "
+            + "Parameters: "
+            + "FILENAME";
+
+    public static final String MESSAGE_SUCCESS = "Employee records have been saved to %s!";
+
+    public static final String MESSAGE_FAILED = "Employee records could not be saved!";
+
+    public final Path filePath;
+
+    /**
+     * Creates an ExportCommand to export records to the specified file name
+     * @param filePath Path to save file to
+     */
+    public ExportCommand(Path filePath) {
+        this.filePath = filePath;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        try {
+            FileUtil.createFile(this.filePath);
+        } catch (IOException e) {
+            throw new CommandException(MESSAGE_FAILED);
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, filePath));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ExportCommand)) {
+            return false;
+        }
+
+        ExportCommand otherExportCommand = (ExportCommand) other;
+        return filePath.equals(otherExportCommand.filePath);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -18,7 +18,7 @@ public class ExportCommand extends Command {
 
     public static final String EXPORT_DEST = "export";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports records from CSV file. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exports records to CSV file. "
             + "Parameters: "
             + "FILENAME";
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+import java.util.Optional;
+
+import seedu.address.commons.controllers.FileDialogHandler;
+import seedu.address.commons.controllers.FileDialogHandlerImpl;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Imports records from file
+ */
+public class ImportCommand extends Command {
+
+    public static final String COMMAND_WORD = "import";
+
+    public static final String MESSAGE_SUCCESS = "Employee records have been imported from %s!";
+
+    public static final String MESSAGE_FAILED = "Employee records were not imported.";
+
+    private final FileDialogHandler fileHandler;
+
+    /**
+     * Constructs a default ImportCommand that triggers a file dialog
+     */
+    public ImportCommand() {
+        fileHandler = new FileDialogHandlerImpl();
+    }
+
+    /**
+     * Constructs an ImportCommand that uses the specified fileHandler. This constructor is primarily used to construct
+     * ImportCommands that use mock FileDialogHandlers.
+     * @param fileHandler FileDialogHandler to invoke when executing the command.
+     */
+    public ImportCommand(FileDialogHandler fileHandler) {
+        this.fileHandler = fileHandler;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        Optional<File> importedFile = fileHandler.openFile("Open Record File", FileDialogHandlerImpl.CSV_EXTENSION);
+        if (importedFile.isEmpty()) {
+            return new CommandResult(MESSAGE_FAILED);
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, importedFile.get().getName()));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,8 +14,10 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -76,6 +78,12 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommand();
+
+        case ExportCommand.COMMAND_WORD:
+            return new ExportCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExportCommandParser.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import seedu.address.commons.controllers.FileDialogHandlerImpl;
+import seedu.address.commons.util.FileUtil;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates an ExportCommand
+ */
+public class ExportCommandParser implements Parser<ExportCommand> {
+
+    private final Path exportFolder = Path.of(ExportCommand.EXPORT_DEST);
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ExportCommand
+     * and returns an ExportCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public ExportCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        boolean inputPathIsDirectory = trimmedArgs.endsWith("/");
+
+        if (!FileUtil.isValidPath(trimmedArgs) || inputPathIsDirectory) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+
+        Path fileName = getFileName(trimmedArgs);
+
+        if (fileName.toString().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+
+        String fileWithExtension = appendExtension(fileName.toString());
+        Path fixedFilePath = exportFolder.resolve(fileWithExtension);
+        return new ExportCommand(fixedFilePath);
+    }
+
+    private Path getFileName(String path) {
+        Path filePath = Paths.get(path);
+        System.out.println(filePath);
+        return filePath.getFileName();
+    }
+
+    /**
+     * Strips the extension provided by the user (if any) and appends the CSV extension
+     * @param path File path provided by user
+     * @return File path containing CSV extension
+     */
+    private String appendExtension(String path) {
+        int extensionPos = path.lastIndexOf('.');
+        boolean pathContainsExtension = extensionPos > -1;
+
+        String pathStrippedExtension;
+        if (pathContainsExtension) {
+            pathStrippedExtension = path.substring(0, extensionPos);
+        } else {
+            pathStrippedExtension = path;
+        }
+
+        return pathStrippedExtension.concat(FileDialogHandlerImpl.CSV_SUFFIX);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -47,7 +47,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
                 filePath, JsonSerializableAddressBook.class);
-        if (!jsonAddressBook.isPresent()) {
+        if (jsonAddressBook.isEmpty()) {
             return Optional.empty();
         }
 

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,73 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+public class ExportCommandTest {
+
+    private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "sandbox", "ExportCommandTest");
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private Path addToTestDataPathIfNotNull(String testFileInTestDataFolder) {
+        return testFileInTestDataFolder != null
+                ? TEST_DATA_FOLDER.resolve(testFileInTestDataFolder)
+                : null;
+    }
+
+    /**
+     * Deletes file specified by the file path, if the file exists. Used to clean up test files to ensure that
+     * a new file is created every time the test is run.
+     * @param filePath Path of file to delete
+     */
+    private void cleanupCreatedFiles(Path filePath) {
+        if (Files.exists(filePath)) {
+            File fileToDelete = new File(filePath.toString());
+            if (!fileToDelete.delete()) {
+                fail(String.format("Could not clean up test file: %s", filePath));
+            }
+        }
+    }
+    @Test
+    public void execute_validFilePath_success() {
+        Path testFilePath = addToTestDataPathIfNotNull("testFile.csv");
+        ExportCommand command = new ExportCommand(testFilePath);
+        String expectedMessage = String.format(ExportCommand.MESSAGE_SUCCESS, testFilePath);
+        assertCommandSuccess(command, model, expectedMessage, model);
+        assertTrue(Files.exists(testFilePath));
+        cleanupCreatedFiles(testFilePath);
+    }
+
+    @Test
+    public void equals() {
+        Path sameFilePath = addToTestDataPathIfNotNull("sameFile.csv");
+        Path diffFilePath = addToTestDataPathIfNotNull("diffFile.csv");
+        ExportCommand exportFirstCommand = new ExportCommand(sameFilePath);
+        ExportCommand exportSecondCommand = new ExportCommand(sameFilePath);
+        ExportCommand exportDiffCommand = new ExportCommand(diffFilePath);
+
+
+        // An export command is equal to itself
+        assertEquals(exportFirstCommand, exportFirstCommand);
+        // Two export commands with the same file path are equal
+        assertEquals(exportFirstCommand, exportSecondCommand);
+        // An export command is not equal to a different type
+        assertNotEquals(exportFirstCommand, 1);
+        // Two export commands with diff file paths are different
+        assertNotEquals(exportFirstCommand, exportDiffCommand);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportCommandTest.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.stage.FileChooser.ExtensionFilter;
+import seedu.address.commons.controllers.FileDialogHandler;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ImportCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_fileChosen_success() {
+        String fileName = "testFile.csv";
+        ImportCommand command = new ImportCommand(new MockSuccessfulFileDialogHandler(fileName));
+        String expectedMessage = String.format(ImportCommand.MESSAGE_SUCCESS, fileName);
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    private static class MockSuccessfulFileDialogHandler implements FileDialogHandler {
+
+        private final String pathname;
+
+        public MockSuccessfulFileDialogHandler(String filename) {
+            this.pathname = filename;
+        }
+
+        @Override
+        public Optional<File> openFile(String title, ExtensionFilter ...extensions) {
+            File outputFile = new File(pathname);
+            return Optional.of(outputFile);
+        }
+    }
+
+    @Test
+    public void execute_fileNotChosen_failed() {
+        ImportCommand command = new ImportCommand(new MockUnsuccessfulFileDialogHandler());
+        String expectedMessage = ImportCommand.MESSAGE_FAILED;
+        assertCommandSuccess(command, model, expectedMessage, model);
+    }
+
+    private static class MockUnsuccessfulFileDialogHandler implements FileDialogHandler {
+        @Override
+        public Optional<File> openFile(String title, ExtensionFilter... extensions) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,6 +7,8 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,8 +21,10 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -69,6 +73,15 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_export() throws Exception {
+        String testFileName = "testExportFile";
+        Path testFilePath = Paths.get(ExportCommand.EXPORT_DEST, "testExportFile.csv");
+        ExportCommand command = (ExportCommand) parser.parseCommand(ExportCommand.COMMAND_WORD + " "
+            + testFileName);
+        assertEquals(new ExportCommand(testFilePath), command);
+    }
+
+    @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
@@ -80,6 +93,12 @@ public class AddressBookParserTest {
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_import() throws Exception {
+        assertTrue(parser.parseCommand(ImportCommand.COMMAND_WORD) instanceof ImportCommand);
+        assertTrue(parser.parseCommand(ImportCommand.COMMAND_WORD + " 3") instanceof ImportCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExportCommandParserTest.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ExportCommand;
+public class ExportCommandParserTest {
+    private final ExportCommandParser parser = new ExportCommandParser();
+
+    @Test
+    public void parse_validFilePaths_success() {
+        Path targetFilePath = Paths.get(ExportCommand.EXPORT_DEST, "TestFile.csv");
+
+        assertParseSuccess(parser, "TestFile", new ExportCommand(targetFilePath));
+        // parser should not append csv more than once
+        assertParseSuccess(parser, "TestFile.csv", new ExportCommand(targetFilePath));
+        // parser should replace invalid file extension provided by user with valid file extension
+        assertParseSuccess(parser, "TestFile.txt", new ExportCommand(targetFilePath));
+        // parser should recognise the supplied extension to be the suffix that follows the last period
+        assertParseSuccess(parser, "TestFile.tar.gz.txt", new ExportCommand(
+                Paths.get(ExportCommand.EXPORT_DEST, "TestFile.tar.gz.csv")
+        ));
+        // parser should extract file name from user input if user provides a path
+        assertParseSuccess(parser, ExportCommand.EXPORT_DEST + "/" + "TestFile",
+                new ExportCommand(targetFilePath));
+        // parser should ignore parent directories
+        assertParseSuccess(parser, "../TestFile", new ExportCommand(targetFilePath));
+        assertParseSuccess(parser, "fakeParentDir/TestFile", new ExportCommand(targetFilePath));
+        assertParseSuccess(parser, "fakeGrandparentDir/fakeParentDir/TestFile.txt",
+                new ExportCommand(targetFilePath));
+    }
+
+    @Test
+    public void parse_invalidFilePaths_failure() {
+        String usageErrorMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE);
+
+        // parser should reject empty inputs, or inputs with only spaces
+        assertParseFailure(parser, "", usageErrorMessage);
+        assertParseFailure(parser, "    ", usageErrorMessage);
+        // parser should reject directories
+        assertParseFailure(parser, "parentDir/", usageErrorMessage);
+    }
+}


### PR DESCRIPTION
The import command triggers a file dialog that allows the user to select the CSV file to import. Users are likely to type in a file path wrongly, hence the choice of a file dialog.

The export command allows the user to input a file name to save the records to. The export command parser ensures that file names provided are valid and will save to the "/exports" folder in CSV format.

Currently, the import command only triggers a file dialog and displays the name of the file selected, while the export command creates an empty file with the file name provided. Future work includes implementing the CSV parser to write the address book in CSV format, as well as parse the CSV file into the address book.