### PR TITLE
Fix leaves' employees not updating their names

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -222,10 +222,10 @@ public class ModelManager implements Model {
         ModelManager otherModelManager = (ModelManager) other;
         // TODO implement leaves import so the below test case passes
         return addressBook.equals(otherModelManager.addressBook)
-                // && leavesBook.equals(otherModelManager.leavesBook)
+                && leavesBook.equals(otherModelManager.leavesBook)
                 && userPrefs.equals(otherModelManager.userPrefs)
-                && filteredPersons.equals(otherModelManager.filteredPersons);
-        // && filteredLeaves.equals(otherModelManager.filteredLeaves);
+                && filteredPersons.equals(otherModelManager.filteredPersons)
+                && filteredLeaves.equals(otherModelManager.filteredLeaves);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/leave/Leave.java
+++ b/src/main/java/seedu/address/model/leave/Leave.java
@@ -113,10 +113,17 @@ public class Leave {
     }
 
     public boolean belongsTo(Person employee) {
-        return this.employee.equals(employee);
+        return this.employee.isSamePerson(employee);
     }
 
+    /**
+     * Creates a new Leave instance with all fields identical to the leave the method is called on,
+     * except with a new person
+     * @param p Person to replace the person field in the leave with
+     * @return New Leave instance containing the person
+     */
     public Leave copyWithNewPerson(Person p) {
+        requireNonNull(p);
         return new Leave(p, title, Range.createNonNullRange(start, end), description, status);
     }
 

--- a/src/main/java/seedu/address/model/leave/UniqueLeaveList.java
+++ b/src/main/java/seedu/address/model/leave/UniqueLeaveList.java
@@ -129,6 +129,7 @@ public class UniqueLeaveList implements Iterable<Leave> {
      * @see Leave#belongsTo(Person)
      */
     public void removePerson(Person p) {
+        requireNonNull(p);
         List<Leave> toRemove = internalList.stream().filter((l) -> l.belongsTo(p)).collect(Collectors.toList());
         toRemove.forEach(this::remove);
     }
@@ -138,6 +139,7 @@ public class UniqueLeaveList implements Iterable<Leave> {
      * @see Leave#belongsTo(Person)
      */
     public void setPerson(Person target, Person editedPerson) {
+        requireAllNonNull(target, editedPerson);
         List<Leave> toEdit = internalList.stream().filter((l) -> l.belongsTo(target)).collect(Collectors.toList());
         toEdit.forEach((l) -> setLeave(l, l.copyWithNewPerson(editedPerson)));
     }

--- a/src/test/data/CsvFiles/typicalLeavesBook.csv
+++ b/src/test/data/CsvFiles/typicalLeavesBook.csv
@@ -1,5 +1,5 @@
 sep=;
 Title;Employee;Start;End;Description;Status
-Alice's Maternity Leave;Alice Pauline;2020-01-01;2020-01-02;Alice's Maternity Leave Description;PENDING
-Benson's Paternity Leave;Benson Meier;2020-01-01;2020-01-02;Benson's Paternity Leave Description;PENDING
+Alice's Maternity Leave;Alice Pauline;2020-01-01;2020-01-05;Alice's Maternity Leave Description;PENDING
+Benson's Paternity Leave;Benson Meier;2020-01-01;2020-01-05;Benson's Paternity Leave Description;PENDING
 Alice's Maternity Leave 2;Alice Pauline;2020-01-03;2020-01-04;;PENDING

--- a/src/test/java/seedu/address/logic/commands/AddLeaveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLeaveCommandTest.java
@@ -46,7 +46,6 @@ import seedu.address.testutil.PersonBuilder;
 
 public class AddLeaveCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), getTypicalLeavesBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), getTypicalLeavesBook(), new UserPrefs());
     @Test
     public void constructor_nullLeave_throwsNullPointerException() {
         Range validDateRange = Range.createNonNullRange(Date.of(VALID_LEAVE_DATE_START),

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -21,7 +21,9 @@ import java.util.List;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
+import seedu.address.model.LeavesBook;
 import seedu.address.model.Model;
+import seedu.address.model.leave.Leave;
 import seedu.address.model.leave.LeaveContainsPersonPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -138,11 +140,15 @@ public class CommandTestUtil {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
-        List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
+        List<Person> expectedFilteredPersonList = new ArrayList<>(actualModel.getFilteredPersonList());
+        LeavesBook expectedLeavesBook = new LeavesBook(actualModel.getLeavesBook());
+        List<Leave> expectedFilteredLeaveList = new ArrayList<>(actualModel.getFilteredLeaveList());
 
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
-        assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
+        assertEquals(expectedFilteredPersonList, actualModel.getFilteredPersonList());
+        assertEquals(expectedLeavesBook, actualModel.getLeavesBook());
+        assertEquals(expectedFilteredLeaveList, actualModel.getFilteredLeaveList());
     }
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandIntegrationTest.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.LeavesBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.leave.Leave;
+import seedu.address.model.leave.PersonEntry;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.LeaveBuilder;
+import seedu.address.testutil.PersonBuilder;
+
+
+public class DeleteCommandIntegrationTest {
+    private Model model;
+
+    private final Person alice = new PersonBuilder()
+            .withName(ALICE.getName().toString())
+            .withAddress(ALICE.getAddress().toString())
+            .withEmail(ALICE.getEmail().toString())
+            .withPhone(ALICE.getPhone().toString()).build();
+    private final Person bob = new PersonBuilder()
+            .withName(BOB.getName().toString())
+            .withAddress(BOB.getAddress().toString())
+            .withEmail(BOB.getEmail().toString())
+            .withPhone(BOB.getPhone().toString()).build();
+
+    private final Leave aliceLeave = new LeaveBuilder().withEmployee(
+            new PersonEntry(ALICE.getName().toString())).build();
+    private final Leave bobLeave = new LeaveBuilder().withEmployee(
+            new PersonEntry(BOB.getName().toString())).build();
+
+    @Test
+    public void execute_deletePerson_success() {
+        // Checks that deleting a person deletes them from both address book as well as their associated leaves
+        // from the leaves book
+        Index deleteCommandIndex = Index.fromOneBased(1);
+        DeleteCommand command = new DeleteCommand(deleteCommandIndex);
+
+        assertNotEquals(aliceLeave.getEmployee(), alice);
+        assertNotEquals(bobLeave.getEmployee(), bob);
+
+        AddressBook ab = new AddressBook();
+        ab.addPerson(alice);
+        ab.addPerson(bob);
+        LeavesBook lb = new LeavesBook();
+        lb.addLeave(aliceLeave);
+        lb.addLeave(bobLeave);
+        model = new ModelManager(ab, lb, new UserPrefs());
+
+        AddressBook expectedAb = new AddressBook();
+        expectedAb.addPerson(bob);
+        LeavesBook expectedLb = new LeavesBook();
+        expectedLb.addLeave(bobLeave);
+        Model expectedModel = new ModelManager(expectedAb, expectedLb, new UserPrefs());
+
+        // ensure that we will be deleting alice
+        assertEquals(model.getFilteredPersonList().get(0), alice);
+
+        assertCommandSuccess(command, model,
+                String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(alice)),
+                expectedModel);
+    }
+
+    @Test
+    public void execute_indexOutOfBounds_throwsCommandException() {
+        Index deleteCommandIndex = Index.fromOneBased(2);
+        DeleteCommand command = new DeleteCommand(deleteCommandIndex);
+
+        AddressBook ab = new AddressBook();
+        ab.addPerson(alice);
+        LeavesBook lb = new LeavesBook();
+        model = new ModelManager(ab, lb, new UserPrefs());
+
+        assertCommandFailure(command, model, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -26,7 +26,7 @@ import seedu.address.model.person.Person;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), getTypicalLeavesBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalLeavesBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {

--- a/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.EditCommand.MESSAGE_DUPLICATE_PERSON;
@@ -77,8 +76,6 @@ public class EditCommandIntegrationTest {
         assertCommandSuccess(command, model,
                 String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)),
                 expectedModel);
-        assertEquals(model.getLeavesBook(), expectedModel.getLeavesBook());
-        assertEquals(model.getFilteredLeaveList(), expectedModel.getFilteredLeaveList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandIntegrationTest.java
@@ -1,0 +1,95 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.EditCommand.MESSAGE_DUPLICATE_PERSON;
+import static seedu.address.logic.commands.EditCommand.MESSAGE_EDIT_PERSON_SUCCESS;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.AddressBook;
+import seedu.address.model.LeavesBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.leave.Leave;
+import seedu.address.model.leave.PersonEntry;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.LeaveBuilder;
+import seedu.address.testutil.PersonBuilder;
+
+
+public class EditCommandIntegrationTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        AddressBook ab = new AddressBook();
+        LeavesBook lb = new LeavesBook();
+        Person person = new PersonBuilder()
+                .withName(ALICE.getName().toString())
+                .withAddress(ALICE.getAddress().toString())
+                .withEmail(ALICE.getEmail().toString())
+                .withPhone(ALICE.getPhone().toString()).build();
+        ab.addPerson(person);
+
+
+        // personEntry used to ensure that leaves are associated to employees via ComparablePerson::isSamePerson
+        // rather than equals
+        Leave loadedLeave = new LeaveBuilder().withEmployee(new PersonEntry(ALICE.getName().toString())).build();
+        lb.addLeave(loadedLeave);
+
+        model = new ModelManager(ab, lb, new UserPrefs());
+    }
+
+    @Test
+    public void execute_renamePerson_success() {
+        // Checks that editing a person's name changes both addressBook and leaveBook entries, even for leaves
+        // that were not created in the current session
+        EditPersonDescriptor editDescriptor = new EditPersonDescriptorBuilder()
+                .withName(BOB.getName().toString()).build();
+
+        Index editCommandIndex = Index.fromOneBased(1);
+        EditCommand command = new EditCommand(editCommandIndex, editDescriptor);
+
+        AddressBook expectedAb = new AddressBook();
+        Person editedPerson = new PersonBuilder()
+                .withName(BOB.getName().toString())
+                .withAddress(ALICE.getAddress().toString())
+                .withEmail(ALICE.getEmail().toString())
+                .withPhone(ALICE.getPhone().toString()).build();
+        expectedAb.addPerson(editedPerson);
+
+        LeavesBook expectedLb = new LeavesBook();
+        Leave expectedLeave = new LeaveBuilder().withEmployee(new PersonEntry(BOB.getName().toString())).build();
+        expectedLb.addLeave(expectedLeave);
+
+        Model expectedModel = new ModelManager(expectedAb, expectedLb, new UserPrefs());
+
+        assertCommandSuccess(command, model,
+                String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)),
+                expectedModel);
+        assertEquals(model.getLeavesBook(), expectedModel.getLeavesBook());
+        assertEquals(model.getFilteredLeaveList(), expectedModel.getFilteredLeaveList());
+    }
+
+    @Test
+    public void execute_duplicatePerson_throwsCommandException() {
+        model.addPerson(BOB);
+
+        EditPersonDescriptor editDescriptor = new EditPersonDescriptorBuilder()
+                .withName(BOB.getName().toString()).build();
+        Index editCommandIndex = Index.fromOneBased(1);
+        EditCommand command = new EditCommand(editCommandIndex, editDescriptor);
+
+        assertCommandFailure(command, model, MESSAGE_DUPLICATE_PERSON);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ImportContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ImportContactCommandTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.FileAndPathUtil.MockSuccessfulFileDialogHandler;
-import static seedu.address.testutil.TypicalLeaves.getTypicalLeavesBook;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.File;
@@ -15,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.stage.FileChooser.ExtensionFilter;
 import seedu.address.commons.controllers.FileDialogHandler;
+import seedu.address.model.LeavesBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -24,7 +24,7 @@ public class ImportContactCommandTest {
     private static final Path TEST_DATA_FOLDER = Paths.get("src", "test", "data", "CsvFiles");
     private static final Path INVALID_ADDRESS_BOOK_PATH = Paths.get("src", "test", "data",
             "CsvAddressBookStorageTest", "validAndInvalidPersonAddressBook.csv");
-    private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalLeavesBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), new LeavesBook(), new UserPrefs());
 
     private Path addToTestDataPathIfNotNull(String filename) {
         return FileAndPathUtil.addToTestDataPathIfNotNull(TEST_DATA_FOLDER, filename);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,8 +3,11 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_LEAVES;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalLeaves.ALICE_LEAVE;
+import static seedu.address.testutil.TypicalLeaves.BENSON_LEAVE;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
@@ -15,6 +18,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.leave.LeaveContainsPersonPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -98,11 +102,17 @@ public class ModelManagerTest {
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();
+
+        LeavesBook leavesBook = new LeavesBook();
+        leavesBook.addLeave(ALICE_LEAVE);
+        leavesBook.addLeave(BENSON_LEAVE);
+        LeavesBook differentLeavesBook = new LeavesBook();
+
         UserPrefs userPrefs = new UserPrefs();
 
         // same values -> returns true
-        modelManager = new ModelManager(addressBook, new LeavesBook(), userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(addressBook, new LeavesBook(), userPrefs);
+        modelManager = new ModelManager(addressBook, leavesBook, userPrefs);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, leavesBook, userPrefs);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -115,19 +125,29 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different addressBook -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, new LeavesBook(), userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, leavesBook, userPrefs)));
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().toString().split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(addressBook, new LeavesBook(), userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, leavesBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
+        // different leavesBook -> returns false
+        assertFalse(modelManager.equals(new ModelManager(addressBook, differentLeavesBook, userPrefs)));
+
+        // different filteredList -> returns false
+        modelManager.updateFilteredLeaveList(new LeaveContainsPersonPredicate(BENSON));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, leavesBook, userPrefs)));
+
+        // resets modelManager to initial state for upcoming tests
+        modelManager.updateFilteredLeaveList(PREDICATE_SHOW_ALL_LEAVES);
+
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
-        assertFalse(modelManager.equals(new ModelManager(addressBook, new LeavesBook(), differentUserPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, leavesBook, differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/address/model/leave/LeaveTest.java
+++ b/src/test/java/seedu/address/model/leave/LeaveTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.person.ComparablePerson;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.LeaveBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class LeaveTest {
 
@@ -72,6 +74,23 @@ public class LeaveTest {
         Leave leave = new Leave(ALICE, ALICE_LEAVE.getTitle(),
                 constructRange(ALICE_LEAVE.getStart(), ALICE_LEAVE.getStart()), ALICE_LEAVE.getDescription());
         assertEquals(leave.getStart(), leave.getEnd());
+    }
+
+    @Test
+    public void copyWithNewPerson_nullPerson_throwsNullExceptionPointer() {
+        assertThrows(NullPointerException.class, () -> new LeaveBuilder().build().copyWithNewPerson(null));
+    }
+
+    @Test
+    public void copyWithNewPerson_success() {
+        Leave existingLeave = new LeaveBuilder().withEmployee(ALICE).build();
+        Leave newLeave = existingLeave.copyWithNewPerson(BOB);
+        assertEquals(newLeave.getEmployee(), BOB);
+        assertEquals(newLeave.getDescription(), existingLeave.getDescription());
+        assertEquals(newLeave.getStart(), existingLeave.getStart());
+        assertEquals(newLeave.getEnd(), existingLeave.getEnd());
+        assertEquals(newLeave.getTitle(), existingLeave.getTitle());
+        assertEquals(newLeave.getStatus(), existingLeave.getStatus());
     }
 
     @Test
@@ -162,6 +181,12 @@ public class LeaveTest {
 
         // different employee -> returns false
         assertFalse(ALICE_LEAVE.belongsTo(BOB));
+
+        // different employee instance but share the same name -> returns true
+        // This test is needed as leaves loaded from storage will not share the same employee
+        // instance as an existing employee instance in the address book
+        Person aliceDuplicate = new PersonBuilder().withName(ALICE.getName().toString()).build();
+        assertTrue(ALICE_LEAVE.belongsTo(aliceDuplicate));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/leave/UniqueLeaveListTest.java
+++ b/src/test/java/seedu/address/model/leave/UniqueLeaveListTest.java
@@ -2,10 +2,14 @@ package seedu.address.model.leave;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalLeaves.ALICE_LEAVE;
 import static seedu.address.testutil.TypicalLeaves.BOB_LEAVE;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.AMY;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.Arrays;
 import java.util.List;
@@ -208,5 +212,90 @@ public class UniqueLeaveListTest {
         // same internal list -> returns true
         uniqueLeaveList.add(ALICE_LEAVE);
         assertTrue(uniqueLeaveList.equals(uniqueLeaveListCopy));
+    }
+
+    @Test
+    public void removePerson_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new UniqueLeaveList().removePerson(null));
+    }
+
+    @Test
+    public void removePerson_personInList_success() {
+        Leave aliceLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(ALICE.getName().toString())).build();
+        Leave bobLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(BOB.getName().toString())).build();
+
+        // ensure we are not comparing based on same instance
+        assertNotEquals(aliceLeave.getEmployee(), ALICE);
+        assertNotEquals(bobLeave.getEmployee(), BOB);
+
+        UniqueLeaveList ull = new UniqueLeaveList();
+        ull.add(aliceLeave);
+        ull.add(bobLeave);
+
+        ull.removePerson(ALICE);
+        assertTrue(ull.contains(bobLeave));
+        assertFalse(ull.contains(aliceLeave));
+    }
+
+    @Test
+    public void removePerson_personNotInList_noChange() {
+        Leave aliceLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(ALICE.getName().toString())).build();
+
+        assertNotEquals(aliceLeave.getEmployee(), BOB);
+
+        UniqueLeaveList ull = new UniqueLeaveList();
+        ull.add(aliceLeave);
+        ull.removePerson(BOB);
+        assertTrue(ull.contains(aliceLeave));
+    }
+
+    @Test
+    public void setPerson_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new UniqueLeaveList().setPerson(null, BOB));
+        assertThrows(NullPointerException.class, () -> new UniqueLeaveList().setPerson(ALICE, null));
+    }
+
+    @Test
+    public void setPerson_personInList_success() {
+        Leave aliceLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(ALICE.getName().toString())).build();
+        Leave bobLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(BOB.getName().toString())).build();
+
+        // ensure we are not comparing based on same instance
+        assertNotEquals(aliceLeave.getEmployee(), ALICE);
+        assertNotEquals(bobLeave.getEmployee(), BOB);
+
+        UniqueLeaveList ull = new UniqueLeaveList();
+        ull.add(aliceLeave);
+        ull.add(bobLeave);
+
+        Leave expectedChangedLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(AMY.getName().toString())).build();
+
+        assertFalse(ull.contains(expectedChangedLeave));
+
+        ull.setPerson(ALICE, AMY);
+        assertTrue(ull.contains(bobLeave));
+        assertFalse(ull.contains(aliceLeave));
+        assertTrue(ull.contains(expectedChangedLeave));
+    }
+
+    @Test
+    public void setPerson_personNotInList_noChange() {
+        Leave aliceLeave = new LeaveBuilder().withEmployee(
+                new PersonEntry(ALICE.getName().toString())).build();
+
+        // ensure we are not comparing based on same instance
+        assertNotEquals(aliceLeave.getEmployee(), ALICE);
+
+        UniqueLeaveList ull = new UniqueLeaveList();
+        ull.add(aliceLeave);
+
+        ull.setPerson(BOB, AMY);
+        assertTrue(ull.contains(aliceLeave));
     }
 }


### PR DESCRIPTION
Leave::belongsTo previously used equals, which is an issue as there is no guarantee that the employee field in the leave contains the same instance as the employee list. By changing it to use ComparablePerson::isSamePerson instead, only the name will be compared, thus fixing the bug.

Test cases were added for Leave and EditCommandIntegrationTest to guarantee that the code produces the desired behaviour.